### PR TITLE
Modify history.html

### DIFF
--- a/front/static/history.html
+++ b/front/static/history.html
@@ -24,7 +24,7 @@ function getParameters()
 var params = getParameters();
 var url = "/error.html";
 if (params && ("orderId" in params)) {
-	url = `/smaphregi/secure?orderId=${params['orderId']}`;
+	url = `/smaphregi/secure/?orderId=${params['orderId']}`;
 }
 window.location = url;
 })();


### PR DESCRIPTION
Amplifyのクエリパラメータ対応。

内容としては下記のissueでも取り上げられている件になります。（ひとまずスラッシュを付ければ解決するというところで）
https://github.com/aws-amplify/amplify-console/issues/792

ちなみに、他のhtmlでもこの対応を実施しておりました。history.htmlは対応漏れてました💦
https://github.com/tacck/line-api-use-case-smart-retail/blob/main/front/static/completed.html#L27